### PR TITLE
Permanently remove .terraform files preventing .Trash growth

### DIFF
--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -414,7 +415,14 @@ class Terraform(RunwayModule[TerraformOptions], DelCachedPropMixin):
                 self.logger.debug("directory retained: %s", child)
                 continue
             self.logger.debug("removing: %s", child)
-            send2trash(str(child))  # does not support Path objects
+            if Path.exists(child):
+                try:
+                    Path.unlink(child)
+                except IsADirectoryError:
+                    shutil.rmtree(child)
+                except OSError:
+                    self.logger.warning("unable to remove %s, sending to .Trash", child)
+                    send2trash(child)  # does not support Path objects
 
     def deploy(self) -> None:
         """Run Terraform apply."""


### PR DESCRIPTION
# Summary
Rather than sending `.terraform` files to the `.Trash` directory, they are attempted to be deleted.  If this fails for some reason, the code falls back to the original functionality.  This doesn't impact the tool execution in any way, it just may clutter up the filesystem so failback should be fine.  

# Why This Is Needed

Users report that repeated runs of terraform will generate large amounts of files in the `.Trash` directory which may be undesirable and can cause file system full situations in pipelines, etc.

# What Changed

## Changed

`.terraform` directory cleanup will remove files rather than move to trash unless deletion fails.


# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you followed the guidelines in our [Contribution Requirements](https://runway.readthedocs.io/page/developers/contributing.html)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?
