### PR TITLE
delete files in `.terraform` rather than sending them to trash

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2897,22 +2897,6 @@ attrs = "*"
 pbr = "*"
 
 [[package]]
-name = "send2trash"
-version = "1.8.3"
-description = "Send file to trash natively under Mac OS X, Windows and Linux"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-files = [
-    {file = "Send2Trash-1.8.3-py3-none-any.whl", hash = "sha256:0c31227e0bd08961c7665474a3d1ef7193929fedda4233843689baa056be46c9"},
-    {file = "Send2Trash-1.8.3.tar.gz", hash = "sha256:b18e7a3966d99871aefeb00cfbcfdced55ce4871194810fc71f4aa484b953abf"},
-]
-
-[package.extras]
-nativelib = ["pyobjc-framework-Cocoa", "pywin32"]
-objc = ["pyobjc-framework-Cocoa"]
-win32 = ["pywin32"]
-
-[[package]]
 name = "setuptools"
 version = "71.0.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -3508,4 +3492,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9, <3.13"
-content-hash = "6001058ff738862292efbb820abc8091ff782e728088bd53749753e3d868c515"
+content-hash = "6e3331fedf68a21badd5dda6a784bc9a85654fd925a43afb59ace049c4d07036"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ pyhcl = "^0.4"  # does not support HCL2, possibly move to extras_require in the 
 python-hcl2 = ">=3.0.0"
 pyyaml = ">5.4"
 requests = "*"
-send2trash = "*"
 tomli = ">=1.2.2"
 troposphere = ">=2.4, <5"
 typing_extensions = "*"  # only really needed for < 3.8 but can still be used in >= 3.8

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import hcl
-from send2trash import send2trash
 from typing_extensions import Literal
 
 from .._logging import PrefixAdaptor
@@ -415,14 +414,10 @@ class Terraform(RunwayModule[TerraformOptions], DelCachedPropMixin):
                 self.logger.debug("directory retained: %s", child)
                 continue
             self.logger.debug("removing: %s", child)
-            if Path.exists(child):
-                try:
-                    Path.unlink(child)
-                except IsADirectoryError:
-                    shutil.rmtree(child)
-                except OSError:
-                    self.logger.warning("unable to remove %s, sending to .Trash", child)
-                    send2trash(child)  # does not support Path objects
+            if child.is_dir():
+                shutil.rmtree(child, ignore_errors=True)
+            else:
+                child.unlink(missing_ok=True)
 
     def deploy(self) -> None:
         """Run Terraform apply."""

--- a/runway/module/terraform.py
+++ b/runway/module/terraform.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -414,7 +415,14 @@ class Terraform(RunwayModule[TerraformOptions], DelCachedPropMixin):
                 self.logger.debug("directory retained: %s", child)
                 continue
             self.logger.debug("removing: %s", child)
-            send2trash(str(child))  # does not support Path objects
+            if Path.exists(child):
+                try:
+                    Path.unlink(child)
+                except IsADirectoryError:
+                    shutil.rmtree(child)
+                except OSError:
+                    self.logger.warning("unable to remove %s, sending to .Trash", child)
+                    send2trash(child)  # does not support Path objects
 
     def deploy(self) -> None:
         """Run Terraform apply."""


### PR DESCRIPTION
# Summary
Rather than sending `.terraform` files to the `.Trash` directory, they are attempted to be deleted.  If this fails for some reason, the code falls back to the original functionality.  This doesn't impact the tool execution in any way, it just may clutter up the filesystem so failback should be fine.  

# Why This Is Needed

Users report that repeated runs of terraform will generate large amounts of files in the `.Trash` directory which may be undesirable and can cause file system full situations in pipelines, etc.

resolves #1952

# What Changed

## Changed

`.terraform` directory cleanup will remove files rather than move to trash unless deletion fails.


# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you followed the guidelines in our [Contribution Requirements](https://runway.readthedocs.io/page/developers/contributing.html)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?