### PR TITLE
add pre-commit.ci badge and remove workflow setup

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -216,8 +216,6 @@ jobs:
           fail_ci_if_error: true
   build-pypi:
     name: Build PyPi 📦
-    needs:
-      - pre-commit
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub (complete)

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -134,19 +134,6 @@ jobs:
         run: make setup-npm
       - name: 🚀 Run Linters
         run: make lint
-  pre-commit:
-    name: pre-commit
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10']
-    steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v4
-      - name: 🏗 Setup Python
-        uses: finleyfamily/action-setup-python@v1.0.0
-      - name: 🚀 Run pre-commit
-        uses: pre-commit/action@v3.0.1
   test-functional:
     name: Functional Tests
     needs:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![codecov](https://codecov.io/gh/rackspace/runway/branch/master/graph/badge.svg?token=Ku28I0RY80)](https://codecov.io/gh/rackspace/runway)
 [![PyPi](https://img.shields.io/pypi/v/runway?style=flat)](https://pypi.org/project/runway/)
 [![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat)](https://github.com/psf/black)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/rackspace/runway/master.svg)](https://results.pre-commit.ci/latest/github/rackspace/runway/master)
 
 ![runway-example.gif](https://raw.githubusercontent.com/rackspace/runway/master/docs/source/images/runway-example.gif)
 


### PR DESCRIPTION
# Summary

# Why This Is Needed
Runs faster and offload execution to `pre-commit.ci`.

Enforce pre-commit execution which cannot be done with local execution.

# What Changed
## Added

`pre-commit.ci` added to repo.

## Changed

`cicd` github action worflow step to run pre-commit removed as it is no longer needed.

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you followed the guidelines in our [Contribution Requirements](https://runway.readthedocs.io/page/developers/contributing.html)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?
