### PR TITLE
add id-token permissions for trusted publish to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
     needs:
       - build-pypi
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: ⤵️ Check out code from GitHub (complete)
         uses: actions/checkout@v4
@@ -56,8 +58,6 @@ jobs:
           poetry-install: false
           poetry-plugins: poetry-dynamic-versioning[plugin]
       - name: 🚀 Publish Distribution 📦 to PyPI
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.pypi_password }}
         run: poetry publish
   notify-on-publish:
     name: Notify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
     needs:
       - build-pypi
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/runway
     permissions:
       id-token: write
     steps:
@@ -58,7 +61,7 @@ jobs:
           poetry-install: false
           poetry-plugins: poetry-dynamic-versioning[plugin]
       - name: 🚀 Publish Distribution 📦 to PyPI
-        run: poetry publish
+        run: pypa/gh-action-pypi-publish@v1.10.1
   notify-on-publish:
     name: Notify
     needs:

--- a/.vscode/dictionaries/pypi.txt
+++ b/.vscode/dictionaries/pypi.txt
@@ -20,6 +20,7 @@ prettytable
 pydantic
 pydocstyle
 pyhcl
+pypa
 pywin
 pyyaml
 runpy


### PR DESCRIPTION

# Summary

Updating the release GHA workflow to use PyPi trusted publisher process vs token.


# Why This Is Needed

Improve security and process by removing long term token.

# What Changed

## Changed

Removed PyPi api token from workflow in favor of OIDC token.


# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Have you followed the guidelines in our [Contribution Requirements](https://runway.readthedocs.io/page/developers/contributing.html)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?
