### PR TITLE
update renovate config to group boto3, ignore quickstart python deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,7 @@
     "ignorePaths": [
         "**/infrastructure/public/common/**",
         "**/node_modules/**",
+        "**/quickstarts/**/pyproject.toml",
         "**/runway/cfngin/hooks/staticsite/auth_at_edge/templates/**",
         "**/runway/templates/**",
         "**/tests/**"
@@ -32,7 +33,8 @@
                 "docs",
                 "lint",
                 "linters",
-                "test"
+                "test",
+                "types"
             ],
             "prPriority": -1
         },
@@ -49,6 +51,26 @@
                 "cspell",
                 "@cspell/{/,}**",
                 "cspell-{/,}**"
+            ]
+        },
+        {
+            "description": "group all `boto3` related packages together",
+            "groupName": "boto3",
+            "matchCategories": [
+                "python"
+            ],
+            "matchPackageNames": [
+                "boto3*",
+                "botocore*",
+                "mypy_boto*",
+                "mypy-boto*",
+                "s3transfer",
+                "types-boto*",
+                "types-s3transfer"
+            ],
+            "schedule": [
+                "after 12am on monday",
+                "before 6am on monday"
             ]
         },
         {
@@ -147,5 +169,6 @@
     "platformAutomerge": true,
     "semanticCommits": "disabled",
     "separateMinorPatch": false,
-    "separateMultipleMajor": true
+    "separateMultipleMajor": true,
+    "stopUpdatingLabel": "status:blocked"
 }


### PR DESCRIPTION
# Summary

Renovate config improvements.

# What Changed

## Changed

- dependencies in group `types` will now be properly labeled with `changelog:skip`
- python packages related to `boto3` will now be grouped together and updates will only be attempted on Monday mornings to reduce frequency
- renovate will stop updating PRs labeled with `status:blocked` until the label is removed (existing label vs renovate's default)
  - would enable PRs like https://github.com/rackspace/runway/pull/2584 to remain open for visibility but excluded from renovate rebasing to reduce action runs
- `**/quickstarts/**/pyproject.toml` is now excluded from renovate updates to prevent PRs like https://github.com/rackspace/runway/pull/2581