### PR TITLE
add setting to explicitly set automergeStrategy to squach

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,6 +40,7 @@
         },
         {
             "automerge": true,
+            "automergeStrategy": "squash",
             "automergeType": "pr",
             "description": "group all `cspell` related packages together and enable automerge",
             "groupName": "cspell",
@@ -78,6 +79,7 @@
                 "changelog:skip"
             ],
             "automerge": true,
+            "automergeStrategy": "squash",
             "automergeType": "pr",
             "description": "automerge devcontainer updates",
             "matchManagers": [
@@ -89,6 +91,7 @@
                 "changelog:skip"
             ],
             "automerge": true,
+            "automergeStrategy": "squash",
             "automergeType": "pr",
             "description": "automerge github actions and runner updates",
             "matchManagers": [
@@ -100,6 +103,7 @@
                 "changelog:skip"
             ],
             "automerge": true,
+            "automergeStrategy": "squash",
             "automergeType": "pr",
             "description": "automerge lockfile updates",
             "gitLabIgnoreApprovals": true,
@@ -123,6 +127,7 @@
         },
         {
             "automerge": true,
+            "automergeStrategy": "squash",
             "automergeType": "pr",
             "description": "npm - bump & automerge",
             "matchManagers": [
@@ -145,6 +150,7 @@
         },
         {
             "automerge": true,
+            "automergeStrategy": "squash",
             "automergeType": "pr",
             "description": "poetry - bump & automerge",
             "matchManagers": [


### PR DESCRIPTION

# Summary

Automerge is not working due to automerge attempting to use `merge-commit` vs `squash` for pr merge.  Therefore, explicitly setting to `squash` which is the only allowed merge type for repo.

# Why This Is Needed

Automerge not working as-is.

# What Changed


## Added

`automergeStrategy: squash` added to renovate configuration.



# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you followed the guidelines in our [Contribution Requirements](https://runway.readthedocs.io/page/developers/contributing.html)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?
