### PR TITLE
replace `:` with `=` to avoid YAML error in some jinja use cases

### DIFF
--- a/runway/cfngin/providers/aws/default.py
+++ b/runway/cfngin/providers/aws/default.py
@@ -1555,7 +1555,7 @@ class Provider(BaseProvider):
             if output_name not in self._outputs[stack.fqn]:
                 self._outputs[stack.fqn][
                     output_name
-                ] = f"<inferred-change: {stack.fqn}.{output_name}={output_params['Value']}>"
+                ] = f"<inferred-change = {stack.fqn}.{output_name}={output_params['Value']}>"
 
         # when creating a changeset for a new stack, CFN creates a temporary
         # stack with a status of REVIEW_IN_PROGRESS. this is only removed if

--- a/tests/unit/cfngin/providers/aws/test_default.py
+++ b/tests/unit/cfngin/providers/aws/test_default.py
@@ -834,7 +834,7 @@ class TestProviderDefaultMode(unittest.TestCase):
             full_changeset=changes, params_diff=[], fqn=stack_name, answer="y"
         )
         expected_outputs = {
-            "FakeOutput": "<inferred-change: MockStack.FakeOutput={'Ref': 'FakeResource'}>"
+            "FakeOutput": "<inferred-change = MockStack.FakeOutput={'Ref': 'FakeResource'}>"
         }
         assert self.provider.get_outputs(stack_name) == expected_outputs
         assert result == expected_outputs


### PR DESCRIPTION

# Summary

Using a `:` in the string causes a yaml mapping error when parsing the string, will use an `=` instead.

# What Changed

## Fixed

Output message uses a `=` instead of a `:` to avoid yaml mapping error.


# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you followed the guidelines in our [Contribution Requirements](https://runway.readthedocs.io/page/developers/contributing.html)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?
