### PR TITLE
remove python setup and change to uses for publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,13 +55,8 @@ jobs:
         with:
           name: pypi-dist
           path: dist
-      - name: 🏗 Setup Python
-        uses: finleyfamily/action-setup-python@v1.1.0
-        with:
-          poetry-install: false
-          poetry-plugins: poetry-dynamic-versioning[plugin]
       - name: 🚀 Publish Distribution 📦 to PyPI
-        run: pypa/gh-action-pypi-publish@v1.12.3
+        uses: pypa/gh-action-pypi-publish@v1.12.3
   notify-on-publish:
     name: Notify
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,6 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: ⤵️ Check out code from GitHub (complete)
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: ⤵️ Download distribution artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION

# Summary

# Why This Is Needed

pypi publish was failing due to incorrect configuration.

# What Changed

## Changed

Removed checkout and setup python step that was not necessary for publish.

## Fixed

replaced `run` with `uses` for publish action.


# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you followed the guidelines in our [Contribution Requirements](https://runway.readthedocs.io/page/developers/contributing.html)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?
