### PR TITLE
remove obsolete settings for poetry upgrade

### DIFF
--- a/.devcontainer/local-features/poetry/install.sh
+++ b/.devcontainer/local-features/poetry/install.sh
@@ -14,8 +14,6 @@ function __configure_poetry {
   poetry config cache-dir "${HOME}/.cache-pypoetry"
   poetry config virtualenvs.create true;
   poetry config virtualenvs.in-project true;
-  poetry config virtualenvs.prefer-active-python true;
-  poetry config warnings.export false;
 }
 
 __install_poetry;


### PR DESCRIPTION


# Summary
Removed the below Poetry config settings:

 `virtualenvs.prefer-active-python`
 `warnings.export`

# Why This Is Needed

Poetry 2.0 upgrade

# What Changed

## Removed

Removed two Poetry config settings no longer valid with `v2.0`.

# Screenshots

<!-- Please include screenshots of any new features to show how it works. -->

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you followed the guidelines in our [Contribution Requirements](https://runway.readthedocs.io/page/developers/contributing.html)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?
