### PR TITLE
update `kubectl` release URL to reflect migration away from GCP

### DIFF
--- a/runway/env_mgr/kbenv.py
+++ b/runway/env_mgr/kbenv.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 LOGGER = cast("RunwayLogger", logging.getLogger(__name__))
 KB_VERSION_FILENAME = ".kubectl-version"
-RELEASE_URI = "https://storage.googleapis.com/kubernetes-release/release"
+RELEASE_URI = "https://dl.k8s.io/release"
 
 
 def verify_kb_release(kb_url: str, download_dir: str, filename: str) -> None:


### PR DESCRIPTION
# Summary

Update `kubectl` release URL to reflect their migration away from using GCP.

The URL contained in this change can be found throughout the install docs - https://kubernetes.io/docs/tasks/tools/

# What Changed

## Changed

- changed value of `RELEASE_URI` to `https://dl.k8s.io/releases`

## Fixed

- fixed issue preventing the installation of `kubectl` ^1.31.0
