### PR TITLE
update `release-drafter` config to support the use of release branches

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -35,12 +35,12 @@ categories:
 category-template: >-
   ### $TITLE
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-commitish: master  # cspell:ignore commitish
 exclude-contributors:
   - dependabot
 exclude-labels:
   - changelog:skip
   - release
+filter-by-commitish: true  # cspell:ignore commitish
 name-template: v$RESOLVED_VERSION
 sort-direction: ascending
 tag-template: v$RESOLVED_VERSION

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -24,3 +24,5 @@ jobs:
           # Using the action token, we would need to push a tag to the repo
           # (instead of creating one from the release interface) then connect
           # the release draft to the tag.
+        with:
+          commitish: ${{ github.ref }}  # cspell:ignore commitish

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - release
+      - release/v*
 
 jobs:
   update_draft_release:


### PR DESCRIPTION
# Summary

Configure `release-drafter` to enable the use of release branches.

# Why This Is Needed

This will enable us to begin development on the `master` branch for the next major release while retaining the ability to patch the current major release.
