### PR TITLE
`ssm` lookup will now accept a falsy default value

### DIFF
--- a/runway/lookups/handlers/ssm.py
+++ b/runway/lookups/handlers/ssm.py
@@ -47,7 +47,10 @@ class SsmLookup(LookupHandler["CfnginContext | RunwayContext"]):
                 **args,
             )
         except client.exceptions.ParameterNotFound:
-            if args.get("default"):
+            if "default" in args:
+                LOGGER.debug(
+                    'unable to resolve SSM parameter "%s"; using default', query, exc_info=True
+                )
                 args.pop("load", None)  # don't load a default value
                 return cls.format_results(args.pop("default"), **args)
             raise


### PR DESCRIPTION
# Summary

SSM lookup will now accept the use of falsy values as default.

# Why This Is Needed

resolves #2396 

# What Changed

## Fixed

- fixed issue preventing the use of falsy values (e.g. empty string) as the default value of the SSM lookup
