### PR TITLE
recommend `detachhead.basedpyright` instead of `pylance`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,10 +2,10 @@
     "recommendations": [
         "DavidAnson.vscode-markdownlint",
         "charliermarsh.ruff",
+        "detachhead.basedpyright",
         "editorconfig.editorconfig",
         "lextudio.restructuredtext",
         "ms-python.python",
-        "ms-python.vscode-pylance",
         "redhat.vscode-yaml",
         "streetsidesoftware.code-spell-checker",
         "tamasfe.even-better-toml"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,6 +41,7 @@
     },
     "files.insertFinalNewline": true,
     "python.analysis.typeCheckingMode": "off",
+    "python.languageServer": "None",
     "python.pythonPath": "${workspaceFolder}/.venv/",
     "python.testing.pytestArgs": [
         "tests",


### PR DESCRIPTION
> [!NOTE]
> This change may be reverted in the future after further testing depending on long term performance impact & feature gap.

# Summary

> [!IMPORTANT]
> `detachhead.basedpyright` has to be uninstalled or disabled for `detachhead.basedpyright` to function properly.

Recommend using vscode extension [`detachhead.basedpyright`](https://marketplace.visualstudio.com/items?itemName=detachhead.basedpyright) over [`ms-python.vscode-pylance`](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance).

This change is being made after researching a better way to keep `pyright` in sync with the version used by the `pylance` vscode extension. `pylance` documents that there is no way to do this while enabling the version of `pyright` to be pinned - https://github.com/microsoft/pylance-release/blob/main/USING_WITH_PYRIGHT.md.

# Why This Is Needed

[`detachhead.basedpyright`](https://marketplace.visualstudio.com/items?itemName=detachhead.basedpyright) uses the version of `pyright` defined within the project rather than a backed in version (like [`ms-python.vscode-pylance`](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)). This provides consistent feedback in vscode, CI, and CLI.

# What Changed

## Changed

- changed recommended vscode extension for python type checking, semantic highlighting, etc for consistency
