### PR TITLE
`runway.cfngin.hooks.awslambda` now checks for restricted args

### DIFF
--- a/runway/cfngin/hooks/awslambda/models/args.py
+++ b/runway/cfngin/hooks/awslambda/models/args.py
@@ -286,7 +286,7 @@ class PythonHookArgs(AwsLambdaHookArgs):
 
     .. important::
       When providing this field, be careful not to duplicate any of the arguments
-      passed by this hook (e.g. ``--requirements``, ``--target``, ``--no-input``).
+      passed by this hook (e.g. ``--requirement``, ``--target``, ``--no-input``).
       Providing duplicate arguments will result in an error.
 
     .. rubric:: Example
@@ -323,3 +323,23 @@ class PythonHookArgs(AwsLambdaHookArgs):
 
     use_poetry: bool = True
     """Whether poetry should be used if determined appropriate."""
+
+    @field_validator("extend_pip_args", mode="after")
+    @classmethod
+    def _validate_extend_pip_args_no_requirement(cls, v: list[str | None]) -> list[str | None]:
+        """Validate that ``--requirement`` is not present in the value."""
+        if v and ("--requirement" in v or "-r" in v):
+            raise ValueError(
+                "can't contain '--requirement' or '-r'; conflicts with arguments provided by the hook"
+            )
+        return v
+
+    @field_validator("extend_pip_args", mode="after")
+    @classmethod
+    def _validate_extend_pip_args_no_target(cls, v: list[str | None]) -> list[str | None]:
+        """Validate that ``--target`` is not present in the value."""
+        if v and ("--target" in v or "-t" in v):
+            raise ValueError(
+                "can't contain '--target' or '-t'; conflicts with arguments provided by the hook"
+            )
+        return v

--- a/tests/unit/cfngin/hooks/awslambda/models/test_args.py
+++ b/tests/unit/cfngin/hooks/awslambda/models/test_args.py
@@ -126,6 +126,36 @@ class TestAwsLambdaHookArgs:
 class TestPythonHookArgs:
     """Test PythonHookArgs."""
 
+    @pytest.mark.parametrize("arg_flag", ["-r", "--requirement"])
+    def test__validate_extend_pip_args_no_requirement(self, arg_flag: str, tmp_path: Path) -> None:
+        """Test _validate_extend_pip_args_no_requirement."""
+        with pytest.raises(
+            ValidationError,
+            match="extend_pip_args\n  "
+            "Value error, can't contain '--requirement' or '-r'; conflicts with arguments provided by the hook",
+        ):
+            PythonHookArgs(
+                bucket_name="test-bucket",
+                extend_pip_args=[arg_flag, "foo.txt"],
+                runtime="test",
+                source_code=tmp_path,
+            )
+
+    @pytest.mark.parametrize("arg_flag", ["-t", "--target"])
+    def test__validate_extend_pip_args_no_target(self, arg_flag: str, tmp_path: Path) -> None:
+        """Test _validate_extend_pip_args_no_target."""
+        with pytest.raises(
+            ValidationError,
+            match="extend_pip_args\n  "
+            "Value error, can't contain '--target' or '-t'; conflicts with arguments provided by the hook",
+        ):
+            PythonHookArgs(
+                bucket_name="test-bucket",
+                extend_pip_args=[arg_flag, "/tmp/foo"],
+                runtime="test",
+                source_code=tmp_path,
+            )
+
     def test_extra(self, tmp_path: Path) -> None:
         """Test extra fields."""
         obj = PythonHookArgs(


### PR DESCRIPTION
# Summary

A `ValueError` will now be raised when trying to pass either `--requirement` or `--target` in the value of `extend_pip_args` to `runway.cfngin.hooks.awslambda`.

# Why This Is Needed

This prevents  the user from providing an argument to `extend_pip_args` that the hook needs to provide to function properly.
In the case of `--target`, it can result in the bypassing of functionality provided by the hook to improve performance.

resolves #2397 

# What Changed

## Changed

- `runway.cfngin.hooks.awslambda` will now raise an error if `extend_pip_args` contains `--requirement` or `--target`
