### PR TITLE
update CFNgin confgin file exclude regex to include docker-compose

### DIFF
--- a/runway/config/__init__.py
+++ b/runway/config/__init__.py
@@ -7,7 +7,7 @@ import re
 import sys
 from pathlib import Path
 from string import Template
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast
 
 import yaml
 
@@ -130,10 +130,14 @@ class CfnginConfig(BaseConfig[CfnginConfigDefinitionModel]):
 
     """
 
-    EXCLUDE_REGEX = r"runway(\..*)?\.(yml|yaml)"
+    # Matches filenames that start with "bitbucket-pipelines", "buildspec",
+    # "docker-compose", or "runway" and end with ".yml" or ".yaml"
+    EXCLUDE_REGEX: ClassVar[str] = (
+        r"(?x)^(bitbucket-pipelines|buildspec|docker-compose|runway)(\..*)?\.(yml|yaml)"
+    )
     """Regex for file names to exclude when looking for config files."""
 
-    EXCLUDE_LIST = ["bitbucket-pipelines.yml", "buildspec.yml", "docker-compose.yml"]
+    EXCLUDE_LIST: ClassVar[list[str]] = []
     """Explicit files names to ignore when looking for config files."""
 
     cfngin_bucket: str | None


### PR DESCRIPTION

# Summary

Exclude regex includes pattern to match explicit filenames, including the addition of `docker-compose` files.

Note: Explicit list left for future use but may be removed in the next major release.


# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you followed the guidelines in our [Contribution Requirements](https://runway.readthedocs.io/page/developers/contributing.html)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?
