### PR TITLE
add filtering for when functional tests should be run

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,8 +25,12 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
+      functional: ${{ steps.filter.outputs.functional }}
+      functional-tests: ${{ steps.filter.outputs.functional-tests }}
       infra-test: ${{ steps.filter.outputs.infrastructure-test }}
       infra-test-alt: ${{ steps.filter.outputs.infrastructure-test-alt }}
+      linting: ${{ steps.filter.outputs.linting }}
+      tests: ${{ steps.filter.outputs.tests }}
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v4  # not needed for pull_request
@@ -36,6 +40,14 @@ jobs:
         id: filter
         with:
           filters: |
+            functional:
+              - 'pyproject.toml'
+              - 'poetry.lock'
+              - 'runway/**'
+              - '!runway/templates/**'
+            functional-tests:
+              - 'tests/conftest.py'
+              - 'tests/functional/**'
             infrastructure-test:
               - 'infrastructure/blueprints/admin_user.py'
               - 'infrastructure/blueprints/cfngin_bucket.py'
@@ -49,6 +61,15 @@ jobs:
               - 'infrastructure/blueprints/prevent_privilege_escalation.py'
               - 'infrastructure/blueprints/test_runner_boundary.py'
               - 'infrastructure/test-alt/common/**'
+            linting:
+              - '**/*.py'
+              - '**/*.pyi'
+              - '.github/workflows/cicd.yml'
+              - 'package-lock.json'
+              - 'package.json'
+            tests:
+              - '.github/workflows/cicd.yml'
+              - 'tests/**'
   info:
     name: Output useful information
     runs-on: ubuntu-latest
@@ -107,6 +128,8 @@ jobs:
         working-directory: infrastructure
   lint-python:
     name: Lint Python
+    needs: changes
+    if: needs.changes.outputs.functional == 'true' || needs.changes.outputs.linting == 'true' || needs.changes.outputs.tests == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -137,10 +160,12 @@ jobs:
   test-functional:
     name: Functional Tests
     needs:
+      - changes
       - deploy-test-infrastructure
       - info
     if: |
       always() &&
+      (needs.changes.outputs.functional == 'true' || needs.changes.outputs.functional-tests == 'true') &&
       needs.info.outputs.is-fork == 'false' &&
       needs.info.outputs.is-actor-bot == 'false' &&
       (needs.deploy-test-infrastructure.result == 'success' || needs.deploy-test-infrastructure.result == 'skipped')
@@ -172,6 +197,8 @@ jobs:
         run: make test-functional
   test-python:
     name: Test Python
+    needs: changes
+    if: needs.changes.outputs.functional == 'true' || needs.changes.outputs.tests == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -29,8 +29,6 @@ jobs:
       functional-tests: ${{ steps.filter.outputs.functional-tests }}
       infra-test: ${{ steps.filter.outputs.infrastructure-test }}
       infra-test-alt: ${{ steps.filter.outputs.infrastructure-test-alt }}
-      linting: ${{ steps.filter.outputs.linting }}
-      tests: ${{ steps.filter.outputs.tests }}
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v4  # not needed for pull_request
@@ -60,15 +58,6 @@ jobs:
               - 'infrastructure/blueprints/prevent_privilege_escalation.py'
               - 'infrastructure/blueprints/test_runner_boundary.py'
               - 'infrastructure/test-alt/common/**'
-            linting:
-              - '**/*.py'
-              - '**/*.pyi'
-              - '.github/workflows/cicd.yml'
-              - 'package-lock.json'
-              - 'package.json'
-            tests:
-              - '.github/workflows/cicd.yml'
-              - 'tests/**'
       - uses: dorny/paths-filter@v3  # cspell:ignore dorny
         id: filter-exclude
         with:
@@ -135,8 +124,6 @@ jobs:
         working-directory: infrastructure
   lint-python:
     name: Lint Python
-    needs: changes
-    if: needs.changes.outputs.functional == 'true' || needs.changes.outputs.linting == 'true' || needs.changes.outputs.tests == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -204,8 +191,6 @@ jobs:
         run: make test-functional
   test-python:
     name: Test Python
-    needs: changes
-    if: needs.changes.outputs.functional == 'true' || needs.changes.outputs.tests == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,7 +25,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      functional: ${{ steps.filter.outputs.functional }}
+      functional: ${{ steps.filter.outputs.functional || steps.filter-exclude.outputs.functional }}
       functional-tests: ${{ steps.filter.outputs.functional-tests }}
       infra-test: ${{ steps.filter.outputs.infrastructure-test }}
       infra-test-alt: ${{ steps.filter.outputs.infrastructure-test-alt }}
@@ -44,7 +44,6 @@ jobs:
               - 'pyproject.toml'
               - 'poetry.lock'
               - 'runway/**'
-              - '!runway/templates/**'
             functional-tests:
               - 'tests/conftest.py'
               - 'tests/functional/**'
@@ -70,6 +69,14 @@ jobs:
             tests:
               - '.github/workflows/cicd.yml'
               - 'tests/**'
+      - uses: dorny/paths-filter@v3  # cspell:ignore dorny
+        id: filter-exclude
+        with:
+          filters: |
+            functional:
+              - 'runway/**'
+              - '!runway/templates/**'
+          predicate-quantifier: every  # was implemented but not added to the action manifest so results in a warning
   info:
     name: Output useful information
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary

Skip running functional tests based on the files that have changed.

# Why This Is Needed

Expedites PRs that don't make functional changes

# What Changed

## Changed

- functional tests will only run if:
  - there was a change to the functional code of runway
  - test infrastructure was changed
  - functional test files were changed