### PR TITLE
`parallel_regions `will now resolve variables prior to processing

### DIFF
--- a/runway/config/components/runway/_deployment_def.py
+++ b/runway/config/components/runway/_deployment_def.py
@@ -44,6 +44,7 @@ class RunwayDeploymentDefinition(ConfigComponentDefinition[RunwayDeploymentDefin
         "assume_role",
         "env_vars",
         "regions",
+        "parallel_regions",
     )
     _supports_vars: tuple[str, ...] = (
         "account_alias",


### PR DESCRIPTION
# Why This Is Needed

`parallel_regions` is evaluated prior to its variables being resolved, resulting in a `UnresolvedVariable`.

resolves https://github.com/rackspace/runway/discussions/2784

# What Changed

## Fixed

- `parallel_regions` added to the pre-process list to ensure variables are resolved prior to deployment.
