### PR TITLE
`parallel_regions` will now resolve variables prior to processing

### DIFF
--- a/runway/config/components/runway/_deployment_def.py
+++ b/runway/config/components/runway/_deployment_def.py
@@ -44,6 +44,7 @@ class RunwayDeploymentDefinition(ConfigComponentDefinition[RunwayDeploymentDefin
         "assume_role",
         "env_vars",
         "regions",
+        "parallel_regions",
     )
     _supports_vars: tuple[str, ...] = (
         "account_alias",


### PR DESCRIPTION

# Summary

# Why This Is Needed

When using `parallel_regions` environment variables are not resolved prior, resulting in error reported previously in issue #2818 

# What Changed

## Fixed
Backport previously fixed issue in PR #2824

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [ ] Have you followed the guidelines in our [Contribution Requirements](https://runway.readthedocs.io/page/developers/contributing.html)?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?
